### PR TITLE
feat(api): Staker Snapshot and Global Staking Stats API 

### DIFF
--- a/src/Coinecta.API/Program.cs
+++ b/src/Coinecta.API/Program.cs
@@ -143,10 +143,11 @@ app.MapPost("/stake/summary", async (IDbContextFactory<CoinectaDbContext> dbCont
         bool isLocked = sp.LockTime > currentTimestamp;
         string? policyId = sp.Amount.MultiAsset.Keys.FirstOrDefault();
         Dictionary<string, ulong> asset = sp.Amount.MultiAsset[policyId!];
-        string assetNameAscii = Encoding.ASCII.GetString(Convert.FromHexString(asset.Keys.FirstOrDefault()!));
+        string assetName = asset.Keys.FirstOrDefault()!;
+        string subject = policyId + assetName;
         ulong total = asset.Values.FirstOrDefault();
 
-        if (result.PoolStats.TryGetValue(assetNameAscii, out StakeStats? value))
+        if (result.PoolStats.TryGetValue(subject, out StakeStats? value))
         {
             value.TotalStaked += total;
             value.TotalPortfolio += total;
@@ -154,7 +155,7 @@ app.MapPost("/stake/summary", async (IDbContextFactory<CoinectaDbContext> dbCont
         }
         else
         {
-            result.PoolStats[assetNameAscii] = new StakeStats
+            result.PoolStats[subject] = new StakeStats
             {
                 TotalStaked = total,
                 TotalPortfolio = total,
@@ -256,7 +257,8 @@ app.MapPost("/stake/positions", async (IDbContextFactory<CoinectaDbContext> dbCo
         double interest = sp.Interest.Numerator / (double)sp.Interest.Denominator;
         string? policyId = sp.Amount.MultiAsset.Keys.FirstOrDefault();
         Dictionary<string, ulong> asset = sp.Amount.MultiAsset[policyId!];
-        string assetNameAscii = Encoding.ASCII.GetString(Convert.FromHexString(asset.Keys.FirstOrDefault()!));
+        string assetName = asset.Keys.FirstOrDefault()!;
+        string subject = policyId + assetName;
         ulong total = asset.Values.FirstOrDefault();
         ulong initial = (ulong)(total / (1 + interest));
         ulong bonus = total - initial;
@@ -264,7 +266,7 @@ app.MapPost("/stake/positions", async (IDbContextFactory<CoinectaDbContext> dbCo
 
         return new
         {
-            Name = assetNameAscii,
+            Subject = subject,
             Total = total,
             UnlockDate = unlockDate,
             Initial = initial,
@@ -272,7 +274,7 @@ app.MapPost("/stake/positions", async (IDbContextFactory<CoinectaDbContext> dbCo
             Interest = interest,
             sp.TxHash,
             sp.TxIndex,
-            sp.StakeKey
+            sp.StakeKey,
         };
     }).OrderByDescending(sp => sp.UnlockDate).ToList();
 

--- a/src/Coinecta.API/Program.cs
+++ b/src/Coinecta.API/Program.cs
@@ -10,6 +10,9 @@ using Coinecta.Data.Services;
 using Coinecta.Data.Utils;
 using CardanoSharp.Wallet.Enums;
 using Coinecta.Models.Api;
+using CardanoSharp.Wallet.Models;
+using CardanoSharp.Wallet.Utilities;
+using Cardano.Sync.Data.Models.Datums;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -181,17 +184,17 @@ app.MapPost("/stake/requests/", async (
 
     int skip = (page - 1) * limit;
 
-    var pagedData = await dbContext.StakeRequestByAddresses
+    List<StakeRequestByAddress> pagedData = await dbContext.StakeRequestByAddresses
         .Where(s => addresses.Contains(s.Address))
         .OrderByDescending(s => s.Slot)
         .Skip(skip)
         .Take(limit)
         .ToListAsync();
 
-    var totalCount = await dbContext.StakeRequestByAddresses
+    int totalCount = await dbContext.StakeRequestByAddresses
         .CountAsync(s => addresses.Contains(s.Address));
 
-    var slotData = pagedData
+    Dictionary<ulong, long> slotData = pagedData
         .DistinctBy(s => s.Slot)
         .ToDictionary(
             s => s.Slot,
@@ -214,7 +217,7 @@ app.MapGet("/stake/requests/pending", async (
 
     int skip = (page - 1) * limit;
 
-    var result = await dbContext.StakeRequestByAddresses
+    List<StakeRequestByAddress> result = await dbContext.StakeRequestByAddresses
         .Where(s => s.Status == StakeRequestStatus.Pending)
         .OrderBy(s => s.Slot)
         .Skip(skip)
@@ -277,8 +280,327 @@ app.MapPost("/stake/positions", async (IDbContextFactory<CoinectaDbContext> dbCo
 .WithName("GetStakePositionsByStakeKeys")
 .WithOpenApi();
 
+app.MapGet("/stake/stats", async (
+    IDbContextFactory<CoinectaDbContext> dbContextFactory,
+    IConfiguration configuration,
+    [FromQuery] ulong? slot) =>
+{
+    using CoinectaDbContext dbContext = dbContextFactory.CreateDbContext();
+
+    IQueryable<StakePositionByStakeKey> stakePositionsQuery = dbContext.StakePositionByStakeKeys
+        .AsNoTracking();
+
+    if (slot.HasValue)
+    {
+        stakePositionsQuery = stakePositionsQuery.Where(s => s.Slot <= slot);
+    }
+
+    var stakePositions = await stakePositionsQuery.GroupBy(s => new { s.TxHash, s.TxIndex })
+        .Where(g => g.Count() < 2)
+        .Select(g => new
+        {
+            g.First().Interest,
+            LockUntil = g.First().LockTime,
+            LockedAsset = g.First().StakePosition.Metadata.Data["locked_assets"],
+            Expiration = g.First().StakePosition.Metadata.Data["name"].Substring(g.First().StakePosition.Metadata.Data["name"].LastIndexOf('-') + 1).Trim()
+        })
+        .ToListAsync();
+
+    slot ??= await dbContext.Blocks.OrderByDescending(b => b.Slot).Select(b => b.Slot).FirstOrDefaultAsync();
+
+    long slotTime = SlotUtility.GetPosixTimeSecondsFromSlot(
+        CoinectaUtils.SlotUtilityFromNetwork(CoinectaUtils.GetNetworkType(configuration)),
+        (long)slot) * 1000;
+
+
+    var groupedByAsset = stakePositions
+        .Select(sp =>
+        {
+            string[] lockedAssets = sp.LockedAsset!.Trim('[', ']').Trim('(', ')').Split(',');
+            LockedAsset asset = new()
+            {
+                PolicyId = lockedAssets[0],
+                AssetName = Encoding.UTF8.GetString(Convert.FromHexString(lockedAssets[1].Trim())),
+                Amount = ulong.Parse(lockedAssets[2])
+            };
+
+            return new
+            {
+                sp.Interest,
+                Asset = asset,
+                sp.LockUntil,
+                sp.Expiration
+            };
+        })
+        .GroupBy(sp => new { sp.Asset.AssetName });
+
+
+    List<PoolStats> groupedByInterest = groupedByAsset
+        .Select(g =>
+        {
+            var groupedByInterest = g.GroupBy(sp => sp.Interest).ToList();
+            Dictionary<ulong, int> nftsByInterest = groupedByInterest.ToDictionary(
+                g => g.Key.Numerator,
+                g => g.Count()
+            );
+
+            Dictionary<ulong, ulong> rewardsByInterest = groupedByInterest.ToDictionary(
+                g => g.Key.Numerator,
+                g =>
+                {
+                    Rational amount = new(g.Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                    Rational interest = new(g.Key.Denominator, Denominator: g.Key.Numerator + g.Key.Denominator);
+                    Rational originalStake = interest * amount;
+                    ulong originalStakeAmount = originalStake.Numerator / originalStake.Denominator;
+                    ulong amountWithStake = amount.Numerator;
+                    return amountWithStake - originalStakeAmount;
+                }
+            );
+
+            Dictionary<ulong, StakeData> stakeStatsByInterest = groupedByInterest.ToDictionary(
+                g => g.Key.Numerator,
+                g =>
+                {
+                    // Total
+                    Rational amount = new(g.Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                    Rational interest = new(g.Key.Denominator, Denominator: g.Key.Numerator + g.Key.Denominator);
+                    Rational originalStakeTotal = interest * amount;
+                    ulong totalAmount = originalStakeTotal.Numerator / originalStakeTotal.Denominator;
+
+                    // Locked
+                    Rational lockedAmount = new(g.Where(sp => sp.LockUntil > (ulong)slotTime).Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                    Rational originalLockedStakeTotal = interest * lockedAmount;
+                    ulong totalLockedAmount = originalLockedStakeTotal.Numerator / originalLockedStakeTotal.Denominator;
+
+                    // Unclaimed
+                    ulong unclaimed = totalAmount - totalLockedAmount;
+
+                    return new StakeData()
+                    {
+                        Total = totalAmount,
+                        Locked = totalLockedAmount,
+                        Unclaimed = unclaimed
+                    };
+                }
+            );
+
+            return new PoolStats()
+            {
+                AssetName = g.Key.AssetName,
+                NftsByInterest = nftsByInterest,
+                RewardsByInterest = rewardsByInterest,
+                StakeDataByInterest = stakeStatsByInterest
+            };
+        })
+        .ToList();
+
+    List<PoolStats> groupedByExpiration = groupedByAsset
+        .Select(g =>
+        {
+            var groupedByExpiration = g.GroupBy(sp => sp.Expiration).ToList();
+            Dictionary<string, int> nftsByExpiration = groupedByExpiration.ToDictionary(
+                g => g.Key,
+                g => g.Count()
+            );
+
+            Dictionary<string, ulong> rewardsByExpiration = groupedByExpiration.ToDictionary(
+                g => g.Key,
+                g =>
+                {
+                    return g.GroupBy(sp => sp.Interest).ToDictionary(
+                        g => g.Key.Numerator,
+                        g =>
+                        {
+                            Rational amount = new(g.Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                            Rational interest = new(g.Key.Denominator, Denominator: g.Key.Numerator + g.Key.Denominator);
+                            Rational originalStake = interest * amount;
+                            ulong originalStakeAmount = originalStake.Numerator / originalStake.Denominator;
+                            ulong amountWithStake = amount.Numerator;
+                            return amountWithStake - originalStakeAmount;
+                        }
+                    ).Select(g => g.Value).Aggregate(0UL, (acc, rewards) => acc + rewards);
+                }
+            );
+
+            Dictionary<string, StakeData> stakeDataByExpiration = groupedByExpiration.ToDictionary(
+                g => g.Key,
+                g =>
+                {
+                    Dictionary<ulong, StakeData> groupedByInterest = g.GroupBy(sp => sp.Interest).ToDictionary(
+                        g => g.Key.Numerator,
+                        g =>
+                        {
+                            // Total
+                            Rational amount = new(g.Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                            Rational interest = new(g.Key.Denominator, Denominator: g.Key.Numerator + g.Key.Denominator);
+                            Rational originalStakeTotal = interest * amount;
+                            ulong totalAmount = originalStakeTotal.Numerator / originalStakeTotal.Denominator;
+
+                            // Locked
+                            Rational lockedAmount = new(g.Where(sp => sp.LockUntil > (ulong)slotTime).Aggregate(0UL, (acc, sp) => acc + sp.Asset.Amount), 1);
+                            Rational originalLockedStakeTotal = interest * lockedAmount;
+                            ulong totalLockedAmount = originalLockedStakeTotal.Numerator / originalLockedStakeTotal.Denominator;
+
+                            // Unclaimed
+                            ulong unclaimed = totalAmount - totalLockedAmount;
+
+                            return new StakeData()
+                            {
+                                Total = totalAmount,
+                                Locked = totalLockedAmount,
+                                Unclaimed = unclaimed
+                            };
+                        }
+                    );
+
+                    return new StakeData()
+                    {
+                        Total = groupedByInterest.Select(g => g.Value.Total).Aggregate(0UL, (acc, total) => acc + total),
+                        Locked = groupedByInterest.Select(g => g.Value.Locked).Aggregate(0UL, (acc, total) => acc + total),
+                        Unclaimed = groupedByInterest.Select(g => g.Value.Unclaimed).Aggregate(0UL, (acc, total) => acc + total)
+                    };
+                }
+            );
+
+            return new PoolStats()
+            {
+                AssetName = g.Key.AssetName,
+                NftsByExpiration = nftsByExpiration,
+                RewardsByExpiration = rewardsByExpiration,
+                StakeDataByExpiration = stakeDataByExpiration
+            };
+        })
+        .ToList();
+
+    List<PoolStats> result = groupedByInterest.GroupJoin(
+        groupedByExpiration,
+        gbi => gbi.AssetName,
+        gbe => gbe.AssetName,
+        (gbi, gbe) =>
+        {
+            PoolStats? expirationStats = gbe.FirstOrDefault();
+            gbi.NftsByExpiration = expirationStats?.NftsByExpiration;
+            gbi.RewardsByExpiration = expirationStats?.RewardsByExpiration;
+            gbi.StakeDataByExpiration = expirationStats?.StakeDataByExpiration;
+            return gbi;
+        }
+    ).ToList();
+
+    return Results.Ok(result);
+})
+.WithName("GetStakePositionsSnapshot")
+.WithOpenApi();
+
+app.MapGet("/stake/snapshot/address/{address}", async (
+    IDbContextFactory<CoinectaDbContext> dbContextFactory,
+    IConfiguration configuration, string address,
+    [FromQuery] ulong? slot) =>
+{
+    using CoinectaDbContext dbContext = dbContextFactory.CreateDbContext();
+
+    IQueryable<NftByAddress> nftsByAddressQuery = dbContext.NftsByAddress
+        .AsNoTracking()
+        .Where(n => n.Address == address);
+
+    IQueryable<StakePositionByStakeKey> stakePositionByStakeKeysQuery = dbContext.StakePositionByStakeKeys
+        .AsNoTracking();
+
+    if (slot.HasValue)
+    {
+        nftsByAddressQuery = nftsByAddressQuery.Where(n => n.Slot <= slot);
+    }
+
+    string stakeKeyPrefix = configuration["StakeKeyPrefix"]!;
+    var stakePositionsByAddress = await nftsByAddressQuery
+        .GroupBy(n => new { n.TxHash, n.OutputIndex, n.PolicyId, n.AssetName })
+        .Where(g => g.Count() < 2)
+        .Select(g => string.Concat(g.First().PolicyId, g.First().AssetName.Substring(stakeKeyPrefix.Length)))
+        .Join(dbContext.StakePositionByStakeKeys, n => n, s => s.StakeKey, (n, s) => new
+        {
+            Amount = s.Amount.MultiAsset.Values.Last().Values.First(),
+            s.Interest
+        })
+        .ToListAsync();
+
+    List<ulong> result = stakePositionsByAddress
+        .Select(sp =>
+        {
+            Rational amount = new(sp.Amount, 1);
+            Rational interest = new(sp.Interest.Denominator, sp.Interest.Numerator + sp.Interest.Denominator);
+            Rational originalStake = interest * amount;
+            return originalStake.Numerator / originalStake.Denominator;
+        })
+        .ToList();
+
+    return Results.Ok(new { UniqueNfts = result.Count, TotalStake = result.Aggregate(0UL, (acc, stake) => acc + stake) });
+})
+.WithName("GetStakeSnapshotByAddress")
+.WithOpenApi();
+
+app.MapGet("/stake/snapshot", async (
+    IDbContextFactory<CoinectaDbContext> dbContextFactory,
+    IConfiguration configuration,
+    [FromQuery] ulong? slot) =>
+{
+    using CoinectaDbContext dbContext = dbContextFactory.CreateDbContext();
+    string stakeKeyPrefix = configuration["StakeKeyPrefix"]!;
+
+    IQueryable<NftByAddress> nftsByAddressQuery = dbContext.NftsByAddress
+        .AsNoTracking();
+
+    IQueryable<StakePositionByStakeKey> stakePositionByStakeKeysQuery = dbContext.StakePositionByStakeKeys
+        .AsNoTracking();
+
+    if (slot.HasValue)
+    {
+        nftsByAddressQuery = nftsByAddressQuery.Where(n => n.Slot <= slot);
+    }
+
+    var stakePositionsByAddress = await nftsByAddressQuery
+        .GroupBy(n => new { n.TxHash, n.OutputIndex, n.PolicyId, n.AssetName })
+        .Where(g => g.Count() < 2)
+        .Select(g => new
+        {
+            Key = string.Concat(g.First().PolicyId, g.First().AssetName.Substring(stakeKeyPrefix.Length)),
+            g.First().Address
+        })
+        .Join(dbContext.StakePositionByStakeKeys, n => n.Key, s => s.StakeKey, (n, s) => new
+        {
+            n.Address,
+            s.Interest,
+            Amount = s.Amount.MultiAsset.Values.Last().Values.First()
+        })
+        .GroupBy(s => s.Address)
+        .ToListAsync();
+
+    var result = stakePositionsByAddress
+        .Select(sp =>
+        {
+            ulong totalStake = sp.Select(s =>
+            {
+                Rational amount = new(s.Amount, 1);
+                Rational interest = new(s.Interest.Denominator, s.Interest.Numerator + s.Interest.Denominator);
+                Rational originalStake = interest * amount;
+                return originalStake.Numerator / originalStake.Denominator;
+            }).Aggregate(0UL, (acc, stake) => acc + stake);
+
+            return new
+            {
+                Address = sp.Key,
+                UniqueNfts = sp.Count(),
+                TotalStake = totalStake
+            };
+        })
+        .ToList();
+
+
+    return Results.Ok(result);
+})
+.WithName("GetAllStakeSnapshotByAddress")
+.WithOpenApi();
+
 app.MapPost("/transaction/stake/add", async (
-    TransactionBuildingService txBuildingService, 
+    TransactionBuildingService txBuildingService,
     ILogger<Program> logger,
     [FromBody] AddStakeRequest request
 ) =>
@@ -298,7 +620,7 @@ app.MapPost("/transaction/stake/add", async (
 .WithOpenApi();
 
 app.MapPost("/transaction/finalize", (
-    TransactionBuildingService txBuildingService, 
+    TransactionBuildingService txBuildingService,
     ILogger<Program> logger,
     [FromBody] FinalizeTransactionRequest request
 ) =>
@@ -318,7 +640,7 @@ app.MapPost("/transaction/finalize", (
 .WithOpenApi();
 
 app.MapPost("/transaction/stake/cancel", async (
-    TransactionBuildingService txBuildingService, 
+    TransactionBuildingService txBuildingService,
     ILogger<Program> logger,
     [FromBody] CancelStakeRequest request
 ) =>
@@ -386,7 +708,7 @@ app.MapGet("/transaction/utxos/{address}", async (IDbContextFactory<CoinectaDbCo
         return Results.BadRequest("Address is required");
     }
 
-    var result = await dbContext.UtxosByAddress
+    List<UtxoByAddress> result = await dbContext.UtxosByAddress
         .Where(u => u.Address == address)
         .GroupBy(u => new { u.TxHash, u.TxIndex }) // Group by both TxHash and TxIndex
         .Where(g => g.Count() < 2)
@@ -402,7 +724,7 @@ app.MapGet("/block/latest", async (IDbContextFactory<CoinectaDbContext> dbContex
 {
     using CoinectaDbContext dbContext = dbContextFactory.CreateDbContext();
 
-    var result = await dbContext.Blocks.OrderByDescending(b => b.Slot).FirstOrDefaultAsync();
+    Cardano.Sync.Data.Models.Block? result = await dbContext.Blocks.OrderByDescending(b => b.Slot).FirstOrDefaultAsync();
 
     return Results.Ok(result);
 })

--- a/src/Coinecta.API/Program.cs
+++ b/src/Coinecta.API/Program.cs
@@ -271,7 +271,8 @@ app.MapPost("/stake/positions", async (IDbContextFactory<CoinectaDbContext> dbCo
             Bonus = bonus,
             Interest = interest,
             sp.TxHash,
-            sp.TxIndex
+            sp.TxIndex,
+            sp.StakeKey
         };
     }).OrderByDescending(sp => sp.UnlockDate).ToList();
 

--- a/src/Coinecta.API/Program.cs
+++ b/src/Coinecta.API/Program.cs
@@ -334,7 +334,6 @@ app.MapGet("/stake/stats", async (
         })
         .GroupBy(sp => new { sp.Asset.AssetName });
 
-
     List<PoolStats> groupedByInterest = groupedByAsset
         .Select(g =>
         {

--- a/src/Coinecta.Catcher/Coinecta.Catcher.csproj
+++ b/src/Coinecta.Catcher/Coinecta.Catcher.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.22" />
+    <PackageReference Include="Pallas.NET" Version="0.1.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Catcher/Coinecta.Catcher.csproj
+++ b/src/Coinecta.Catcher/Coinecta.Catcher.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.20" />
+    <PackageReference Include="Pallas.NET" Version="0.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Catcher/Worker.cs
+++ b/src/Coinecta.Catcher/Worker.cs
@@ -135,10 +135,13 @@ public class Worker(
                         ulong stakeAmount = stakeRequest.StakePoolProxy.AssetAmount;
                         Rational rewardMultiplier = stakeRequest.StakePoolProxy.RewardMultiplier;
                         Rational rewardTotalRational = new Rational(stakeAmount, 1) * rewardMultiplier;
-                        ulong rewardTotal = rewardTotalRational.Floor();
+                        ulong rewardTotal = rewardTotalRational.Numerator / rewardTotalRational.Denominator;
+
+                        _logger.LogInformation("Stake Amount: {stakeAmount} Remaining Liquidity: {remainingLiquidity}. Reward Total: {rewardTotal}.", stakeAmount, remainingLiquidity, rewardTotal);
 
                         if (remainingLiquidity < rewardTotal)
                         {
+                            _logger.LogInformation("Stake Amount: {stakeAmount} Remaining Liquidity: {remainingLiquidity}. Reward Total: {rewardTotal}.", stakeAmount, remainingLiquidity, rewardTotal);
                             _logger.LogInformation("Stake Pool has insufficient liquidity for Stake Request: {stakeRequest.TxHash}", stakeRequest.TxHash);
                             CatcherState.CurrentStakePoolStates = null;
                             await UpdateCurrentStakePoolsAsync();

--- a/src/Coinecta.Data/Coinecta.Data.csproj
+++ b/src/Coinecta.Data/Coinecta.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.11-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.13-alpha" />
     <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Coinecta.Data/Coinecta.Data.csproj
+++ b/src/Coinecta.Data/Coinecta.Data.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.11-alpha" />
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.0.2" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Coinecta.Data/CoinectaDbContext.cs
+++ b/src/Coinecta.Data/CoinectaDbContext.cs
@@ -17,6 +17,7 @@ public class CoinectaDbContext
     public DbSet<StakeRequestByAddress> StakeRequestByAddresses { get; set; }
     public DbSet<StakePositionByStakeKey> StakePositionByStakeKeys { get; set; }
     public DbSet<UtxoByAddress> UtxosByAddress { get; set; }
+    public DbSet<NftByAddress> NftsByAddress { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -28,6 +29,7 @@ public class CoinectaDbContext
         modelBuilder.Entity<StakePositionByStakeKey>().OwnsOne(item => item.Amount);
         modelBuilder.Entity<StakePositionByStakeKey>().OwnsOne(item => item.Interest);
         modelBuilder.Entity<UtxoByAddress>().HasKey(item => new { item.Address, item.Slot, item.TxHash, item.TxIndex, item.Status });
+        modelBuilder.Entity<NftByAddress>().HasKey(item => new { item.TxHash, item.OutputIndex, item.Slot, item.PolicyId, item.AssetName, item.UtxoStatus });
         base.OnModelCreating(modelBuilder);
     }
 }

--- a/src/Coinecta.Data/Migrations/20240318105342_NftByAddress.Designer.cs
+++ b/src/Coinecta.Data/Migrations/20240318105342_NftByAddress.Designer.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Coinecta.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Coinecta.Data.Migrations
 {
     [DbContext(typeof(CoinectaDbContext))]
-    partial class CoinectaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240318105342_NftByAddress")]
+    partial class NftByAddress
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Coinecta.Data/Migrations/20240318105342_NftByAddress.cs
+++ b/src/Coinecta.Data/Migrations/20240318105342_NftByAddress.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Coinecta.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class NftByAddress : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "NftsByAddress",
+                schema: "coinecta",
+                columns: table => new
+                {
+                    TxHash = table.Column<string>(type: "text", nullable: false),
+                    OutputIndex = table.Column<decimal>(type: "numeric(20,0)", nullable: false),
+                    Slot = table.Column<decimal>(type: "numeric(20,0)", nullable: false),
+                    PolicyId = table.Column<string>(type: "text", nullable: false),
+                    AssetName = table.Column<string>(type: "text", nullable: false),
+                    UtxoStatus = table.Column<int>(type: "integer", nullable: false),
+                    Address = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_NftsByAddress", x => new { x.TxHash, x.OutputIndex, x.Slot, x.PolicyId, x.AssetName, x.UtxoStatus });
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "NftsByAddress",
+                schema: "coinecta");
+        }
+    }
+}

--- a/src/Coinecta.Data/Models/Api/LockedAsset.cs
+++ b/src/Coinecta.Data/Models/Api/LockedAsset.cs
@@ -1,0 +1,8 @@
+namespace Coinecta.Data.Models.Api;
+
+public record LockedAsset
+{
+    public string PolicyId { get; init; } = default!;
+    public string AssetName { get; init; } = default!;
+    public ulong Amount { get; init; }
+}

--- a/src/Coinecta.Data/Models/Api/PoolStats.cs
+++ b/src/Coinecta.Data/Models/Api/PoolStats.cs
@@ -1,0 +1,12 @@
+namespace Coinecta.Data.Models.Api;
+
+public record PoolStats
+{
+    public string AssetName { get; set; } = default!;
+    public Dictionary<ulong, int>? NftsByInterest { get; set; } = [];
+    public Dictionary<ulong, ulong>? RewardsByInterest { get; set; } = [];
+    public Dictionary<ulong, StakeData>? StakeDataByInterest { get; set; } = [];
+    public Dictionary<string, int>? NftsByExpiration { get; set; } = [];
+    public Dictionary<string, ulong>? RewardsByExpiration { get; set; } = [];
+    public Dictionary<string, StakeData>? StakeDataByExpiration { get; set; } = [];
+}

--- a/src/Coinecta.Data/Models/Api/StakeData.cs
+++ b/src/Coinecta.Data/Models/Api/StakeData.cs
@@ -1,0 +1,8 @@
+namespace Coinecta.Data.Models.Api;
+
+public record StakeData
+{
+    public ulong Total { get; init; }
+    public ulong Locked { get; init; }
+    public ulong Unclaimed { get; init; }
+}

--- a/src/Coinecta.Data/Models/Reducers/NftByAddress.cs
+++ b/src/Coinecta.Data/Models/Reducers/NftByAddress.cs
@@ -1,0 +1,14 @@
+using Coinecta.Data.Models.Enums;
+
+namespace Coinecta.Data.Models.Reducers;
+
+public record NftByAddress
+{
+    public string Address { get; init; } = default!;
+    public string TxHash { get; init; } = default!;
+    public ulong OutputIndex { get; init; }
+    public ulong Slot { get; init; }
+    public string PolicyId { get; init; } = default!;
+    public string AssetName { get; init; } = default!;
+    public UtxoStatus UtxoStatus { get; set; }
+}

--- a/src/Coinecta.Data/Services/TransactionBuildingService.cs
+++ b/src/Coinecta.Data/Services/TransactionBuildingService.cs
@@ -187,7 +187,7 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
 
         walletUtxos = CoinectaUtils.GetPureAdaUtxos(walletUtxos);
         CoinSelection coinSelectionResult = CoinectaUtils
-            .GetCoinSelection([collateralOutput], walletUtxos, changeAddress.ToString())
+            .GetCoinSelection([collateralOutput], walletUtxos, changeAddress.ToString(), limit: 1)
                 ?? throw new Exception("Coin selection failed");
 
         RedeemerBuilder? redeemerBuilder = RedeemerBuilder.Create
@@ -419,7 +419,7 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
         };
 
         walletUtxos = CoinectaUtils.GetPureAdaUtxos(walletUtxos);
-        CoinSelection collateralInputResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, walletAddress.ToString());
+        CoinSelection collateralInputResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, walletAddress.ToString(), limit: 1);
         collateralInputResult.Inputs.ForEach(input => txBodyBuilder.AddCollateralInput(input));
 
         List<TransactionInput> txInputs = [.. txBodyBuilder.Build().TransactionInputs];
@@ -781,7 +781,7 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
             };
 
             walletUtxos = CoinectaUtils.GetPureAdaUtxos(walletUtxos);
-            CoinSelection batcherCollateralCoinSelectionResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, changeAddress.ToString());
+            CoinSelection batcherCollateralCoinSelectionResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, changeAddress.ToString(), limit: 1);
             List<TransactionInput> collateralInputs = batcherCollateralCoinSelectionResult.Inputs;
             collateralInputs.ForEach(input => txBodyBuilder.AddCollateralInput(input));
         }

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -164,7 +164,7 @@ public static class CoinectaUtils
         List<Utxo>? requiredUtxos = null,
         int limit = 20, ulong feeBuffer = 0uL)
     {
-        RandomImproveStrategy coinSelectionStrategy = new();
+        OptimizedRandomImproveStrategy coinSelectionStrategy = new();
         SingleTokenBundleStrategy changeCreationStrategy = new();
         CoinSelectionService coinSelectionService = new(coinSelectionStrategy, changeCreationStrategy);
 

--- a/src/Coinecta.Sync/Coinecta.Sync.csproj
+++ b/src/Coinecta.Sync/Coinecta.Sync.csproj
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.11-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.13-alpha" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.22" />
+    <PackageReference Include="Pallas.NET" Version="0.1.23" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Sync/Coinecta.Sync.csproj
+++ b/src/Coinecta.Sync/Coinecta.Sync.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.0.2" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
@@ -18,7 +18,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.11-alpha" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.20" />
+    <PackageReference Include="Pallas.NET" Version="0.1.22" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Sync/Program.cs
+++ b/src/Coinecta.Sync/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddSingleton<IReducer, StakePoolByAddressReducer>();
 builder.Services.AddSingleton<IReducer, StakeRequestByAddressReducer>();
 builder.Services.AddSingleton<IReducer, StakePositionByStakeKeyReducer>();
 builder.Services.AddSingleton<IReducer, UtxosByAddressReducer>();
+builder.Services.AddSingleton<IReducer, NftByAddressReducer>();
 
 builder.Services.AddCardanoIndexer<CoinectaDbContext>(builder.Configuration, 60);
 

--- a/src/Coinecta.Sync/Reducers/NftByAddressReducer.cs
+++ b/src/Coinecta.Sync/Reducers/NftByAddressReducer.cs
@@ -1,0 +1,122 @@
+using Cardano.Sync.Reducers;
+using Coinecta.Data;
+using Coinecta.Data.Models.Enums;
+using Coinecta.Data.Models.Reducers;
+using Microsoft.EntityFrameworkCore;
+using PallasDotnet.Models;
+
+namespace Coinecta.Sync.Reducers;
+
+public class NftByAddressReducer(
+    IDbContextFactory<CoinectaDbContext> dbContextFactory,
+    IConfiguration configuration,
+    ILogger<NftByAddressReducer> logger
+) : IReducer
+{
+    private readonly string _stakeKeyPolicyId = configuration["CoinectaStakeKeyPolicyId"]!;
+    private readonly string _stakeKeyPrefix = configuration["StakeKeyPrefix"]!;
+    private CoinectaDbContext _dbContext = default!;
+    private readonly ILogger<NftByAddressReducer> _logger = logger;
+
+    public async Task RollBackwardAsync(NextResponse response)
+    {
+        using CoinectaDbContext _dbContext = dbContextFactory.CreateDbContext();
+
+        // Remove all entries with slot greater than the rollback slot
+        ulong rollbackSlot = response.Block.Slot;
+        IQueryable<NftByAddress> rollbackEntries = _dbContext.NftsByAddress.AsNoTracking().Where(lba => lba.Slot > rollbackSlot);
+        _dbContext.NftsByAddress.RemoveRange(rollbackEntries);
+
+        // Save changes
+        await _dbContext.SaveChangesAsync();
+        await _dbContext.DisposeAsync();
+    }
+
+    public async Task RollForwardAsync(NextResponse response)
+    {
+        _dbContext = dbContextFactory.CreateDbContext();
+        IEnumerable<TransactionBody> transactions = response.Block.TransactionBodies;
+
+        foreach (var tx in transactions)
+        {
+            await ProcessInputAync(response.Block, tx);
+            await ProcessOutputAync(response.Block, tx);
+        }
+
+        await _dbContext.SaveChangesAsync();
+        await _dbContext.DisposeAsync();
+    }
+
+    private async Task ProcessInputAync(Block block, TransactionBody tx)
+    {
+        foreach (TransactionInput input in tx.Inputs)
+        {
+            // First check in-memory data
+            List<NftByAddress> nftByAddresses = _dbContext.NftsByAddress.Local
+                .Where(s => s.TxHash == input.Id.ToHex())
+                .Where(s => s.OutputIndex == input.Index)
+                .ToList();
+
+            // Then check the database
+            nftByAddresses = nftByAddresses.Count > 0 ? nftByAddresses : await _dbContext.NftsByAddress
+                .Where(s => s.TxHash == input.Id.ToHex())
+                .Where(s => s.OutputIndex == input.Index)
+                .ToListAsync();
+
+            nftByAddresses.ForEach(nftByAddress =>
+            {
+                NftByAddress spentNftByAddress = new()
+                {
+                    Address = nftByAddress.Address,
+                    TxHash = nftByAddress.TxHash,
+                    OutputIndex = nftByAddress.OutputIndex,
+                    Slot = block.Slot,
+                    PolicyId = nftByAddress.PolicyId,
+                    AssetName = nftByAddress.AssetName,
+                    UtxoStatus = UtxoStatus.Spent
+                };
+
+                _dbContext.NftsByAddress.Add(spentNftByAddress);
+            });
+        }
+    }
+
+    private Task ProcessOutputAync(Block block, TransactionBody tx)
+    {
+        tx.Outputs.ToList().ForEach(output =>
+        {
+            string addressBech32 = output.Address.ToBech32();
+            if (addressBech32.StartsWith("addr"))
+            {
+                var assets = output.Amount.MultiAsset
+                    .ToDictionary(k => k.Key.ToHex(), v => v.Value.ToDictionary(
+                        k => k.Key.ToHex(),
+                        v => v.Value
+                    ))
+                    .SelectMany(outer => outer.Value, (outer, inner) => (outer.Key, inner.Key, inner.Value))
+                    .ToList();
+
+                foreach (var (policyId, assetName, amount) in assets)
+                {
+                    if (policyId == _stakeKeyPolicyId && assetName.StartsWith(_stakeKeyPrefix))
+                    {
+                        var nftByAddress = new NftByAddress
+                        {
+                            Address = addressBech32,
+                            TxHash = tx.Id.ToHex(),
+                            OutputIndex = output.Index,
+                            Slot = block.Slot,
+                            PolicyId = policyId,
+                            AssetName = assetName,
+                            UtxoStatus = UtxoStatus.Unspent
+                        };
+
+                        _dbContext.NftsByAddress.Add(nftByAddress);
+                    }
+                }
+            }
+        });
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Coinecta.Sync/Reducers/StakePoolByAddressReducer.cs
+++ b/src/Coinecta.Sync/Reducers/StakePoolByAddressReducer.cs
@@ -35,17 +35,12 @@ public class StakePoolByAddressReducer(
 
         foreach (TransactionBody txBody in response.Block.TransactionBodies)
         {
-            await ProcessTransactionBodyAsync(response.Block, txBody);
+            await ProcessInputAync(response.Block, txBody);
+            await ProcessOutputAync(response.Block, txBody);
         }
 
         await _dbContext.SaveChangesAsync();
         _dbContext.Dispose();
-    }
-
-    private async Task ProcessTransactionBodyAsync(Block block, TransactionBody tx)
-    {
-        await ProcessInputAync(block, tx);
-        await ProcessOutputAync(block, tx);
     }
 
     private async Task ProcessInputAync(Block block, TransactionBody tx)

--- a/src/Coinecta.Sync/Reducers/StakePositionByStakeKeyReducer.cs
+++ b/src/Coinecta.Sync/Reducers/StakePositionByStakeKeyReducer.cs
@@ -35,18 +35,14 @@ public class StakePositionByStakeKeyReducer(
 
         foreach (TransactionBody txBody in response.Block.TransactionBodies)
         {
-            await ProcessTransactionBodyAsync(response.Block, txBody);
+            await ProcessInputAync(response.Block, txBody);
+            await ProcessOutputAync(response.Block, txBody);
         }
 
         await _dbContext.SaveChangesAsync();
         _dbContext.Dispose();
     }
 
-    private async Task ProcessTransactionBodyAsync(Block block, TransactionBody tx)
-    {
-        await ProcessInputAync(block, tx);
-        await ProcessOutputAync(block, tx);
-    }
 
     private async Task ProcessInputAync(Block block, TransactionBody tx)
     {

--- a/src/Coinecta.Tests/Coinecta.Tests.csproj
+++ b/src/Coinecta.Tests/Coinecta.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Dahomey.Cbor" Version="1.21.0" />
     <PackageReference Include="PeterO.Cbor" Version="4.5.3" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.10-alpha" />
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.0.1" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="System.Formats.Cbor" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
## Overview
This PR introduces three new endpoints to the Coinecta.API project, a new indexer to track stake key NFTS to the Coinecta.Sync project, and updating the coin selection algorithm in the TransactionBuilding service for improved performance. This change closes #1.

### New Endpoints

- `GET /stake/snapshot/address/{address}`: Fetches a stake snapshot for a specific address. An optional `slot` query parameter can be used to retrieve the snapshot at a specific slot.
  
- `GET /stake/snapshot`: Retrieves stake snapshots for all addresses. Supports an optional `slot` query parameter to specify the slot for snapshot retrieval.

- `GET /stake/stats`: Provides global staking statistics, categorized by reward interest and expiration/unlock data.

### NftsByAddress Indexer

- Added a new indexer that tracks the movement of stake key NFTs to enable the snapshot endpoints. 

### Catcher Reward Calculation Fix

- Minor fix to the way the catcher calculates if the stake pool has enough liquidity to process the request.

### TransactionBuilding Service Update

- Updated the coin selection algorithm to use the "OptimizedRandomImprove" strategy, following [Orion-Crypto's recent update](https://github.com/Orion-Crypto/cardanosharp-wallet/commit/7a7747caba3be22b0885b0c57ad47134ef968a1b). This new strategy optimizes the selection process for efficiency and cost-effectiveness.

### Minor Update

- Updated some libraries to the latest version



