### PR TITLE
feat(catcher): Integrate UTXO By Address 

### DIFF
--- a/src/Coinecta.API/Coinecta.API.csproj
+++ b/src/Coinecta.API/Coinecta.API.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-    <PackageReference Include="Pallas.NET" Version="0.1.27" />
+    <PackageReference Include="Pallas.NET" Version="0.1.28" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>

--- a/src/Coinecta.API/Coinecta.API.csproj
+++ b/src/Coinecta.API/Coinecta.API.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
+    <PackageReference Include="Pallas.NET" Version="0.1.27" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
   </ItemGroup>

--- a/src/Coinecta.API/Program.cs
+++ b/src/Coinecta.API/Program.cs
@@ -734,9 +734,10 @@ app.MapGet("/transaction/utxos/raw/{address}", async (string address) =>
 {
     CardanoNodeClient client = new();
     await client.ConnectAsync(builder.Configuration["CardanoNodeSocketPath"]!, builder.Configuration.GetValue<uint>("CardanoNetworkMagic"));
-    var utxosByAddress = await client.GetUtxosByAddressAsync(address);
-    var result = utxosByAddress.Values.Select(u =>
+    Cardano.Sync.Data.Models.Experimental.UtxosByAddress utxosByAddress = await client.GetUtxosByAddressAsync(address);
+    List<string> result = utxosByAddress.Values.Select(u =>
         Convert.ToHexString(CBORObject.NewArray().Add(u.Key.Value.GetCBOR()).Add(u.Value.Value.GetCBOR()).EncodeToBytes()).ToLowerInvariant()).ToList();
+
     return Results.Ok(result);
 })
 .WithName("GetAddressRawUtxos")

--- a/src/Coinecta.Catcher/Coinecta.Catcher.csproj
+++ b/src/Coinecta.Catcher/Coinecta.Catcher.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.27" />
+    <PackageReference Include="Pallas.NET" Version="0.1.28" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Catcher/Coinecta.Catcher.csproj
+++ b/src/Coinecta.Catcher/Coinecta.Catcher.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.23" />
+    <PackageReference Include="Pallas.NET" Version="0.1.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Catcher/Worker.cs
+++ b/src/Coinecta.Catcher/Worker.cs
@@ -20,6 +20,9 @@ using Coinecta.Data.Utils;
 using Coinecta.Data.Extensions;
 using TransactionOutput = CardanoSharp.Wallet.Models.Transactions.TransactionOutput;
 using Cardano.Sync.Data.Models.Datums;
+using Cardano.Sync;
+using Cardano.Sync.Data.Models.Experimental;
+using PeterO.Cbor2;
 
 namespace Coinecta.Catcher;
 
@@ -186,9 +189,7 @@ public class Worker(
     private async Task<Utxo> GetUpdatedCertificateUtxoAsync()
     {
         _logger.LogInformation("Fetching Certificate Utxo...");
-        List<UtxoByAddress> result = await FetchUtxosAsync();
-
-        List<Utxo> utxos = CoinectaUtils.ConvertUtxosByAddressToUtxo(result);
+        List<Utxo>? utxos = await FetchUtxosAsync() ?? throw new Exception("Error while fetching utxos.");
         ITokenBundleBuilder catcherTokenBundle = TokenBundleBuilder.Create;
         catcherTokenBundle.AddToken(Convert.FromHexString(CatcherState.CatcherCertificatePolicyId), Convert.FromHexString(CatcherState.CatcherCertificateAssetName), 1);
 
@@ -212,8 +213,7 @@ public class Worker(
     private async Task<Utxo> GetUpdatedCollateralUtxoAsync()
     {
         _logger.LogInformation("Fetching Collateral Utxo...");
-        List<UtxoByAddress> result = await FetchUtxosAsync();
-        List<Utxo> utxos = CoinectaUtils.ConvertUtxosByAddressToUtxo(result);
+        List<Utxo>? utxos = await FetchUtxosAsync() ?? throw new Exception("Error while fetching utxos.");
         utxos = CoinectaUtils.GetPureAdaUtxos(utxos);
 
         TransactionOutput collateralOutput = new()
@@ -282,30 +282,26 @@ public class Worker(
         return [];
     }
 
-    private async Task<List<UtxoByAddress>> FetchUtxosAsync()
+    private async Task<List<Utxo>?> FetchUtxosAsync()
     {
         try
         {
-            HttpResponseMessage response = await CoinectaApi.GetAsync($"/transaction/utxos/{CatcherState.CatcherAddress}");
+            CardanoNodeClient client = new();
+            await client.ConnectAsync(configuration["CardanoNodeSocketPath"]!, configuration.GetValue<uint>("CardanoNetworkMagic"));
 
-            if (response.IsSuccessStatusCode)
-            {
-                string jsonString = await response.Content.ReadAsStringAsync();
-                List<UtxoByAddress>? utxosByAddress = JsonSerializer.Deserialize<List<UtxoByAddress>>(jsonString, jsonSerializerOptions);
-                return utxosByAddress ?? [];
-            }
-            else
-            {
-                // Handle error response
-                _logger.LogInformation("Error while fetching utxos. Status Code: {StatusCode}", response.StatusCode);
-            }
+            UtxosByAddress utxosByAddress = await client.GetUtxosByAddressAsync(CatcherState.CatcherAddress.ToString());
+            List<string> rawUtxosByAddress = utxosByAddress.Values.Select(u =>
+                Convert.ToHexString(CBORObject.NewArray().Add(u.Key.Value.GetCBOR()).Add(u.Value.Value.GetCBOR()).EncodeToBytes()).ToLowerInvariant()).ToList();
+            List<Utxo> utxos = CoinectaUtils.ConvertUtxoListCbor(rawUtxosByAddress).ToList();
+
+            return utxos;
         }
         catch (Exception e)
         {
             _logger.LogInformation("Error while fetching utxos: {e}", e.Message);
         }
 
-        return [];
+        return null;
     }
 
     private async Task<Block?> FetchLatestBlockAsync()

--- a/src/Coinecta.Data/Coinecta.Data.csproj
+++ b/src/Coinecta.Data/Coinecta.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.16-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.17-alpha" />
     <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Coinecta.Data/Coinecta.Data.csproj
+++ b/src/Coinecta.Data/Coinecta.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.13-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.16-alpha" />
     <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
   </ItemGroup>
 </Project>

--- a/src/Coinecta.Data/Coinecta.Data.csproj
+++ b/src/Coinecta.Data/Coinecta.Data.csproj
@@ -10,6 +10,6 @@
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.16-alpha" />
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.1" />
   </ItemGroup>
 </Project>

--- a/src/Coinecta.Data/Extensions/TransactionExtension.cs
+++ b/src/Coinecta.Data/Extensions/TransactionExtension.cs
@@ -1,4 +1,5 @@
 using System.Formats.Cbor;
+using Cardano.Sync.Data.Models;
 using Cardano.Sync.Data.Models.Datums;
 using CardanoSharp.Wallet.Extensions.Models;
 using CardanoSharp.Wallet.Extensions.Models.Transactions;

--- a/src/Coinecta.Data/Models/Datums/StakePoolProxy.cs
+++ b/src/Coinecta.Data/Models/Datums/StakePoolProxy.cs
@@ -1,4 +1,5 @@
 using System.Formats.Cbor;
+using Cardano.Sync.Data.Models;
 using Cardano.Sync.Data.Models.Datums;
 using CborSerialization;
 

--- a/src/Coinecta.Data/Services/TransactionBuildingService.cs
+++ b/src/Coinecta.Data/Services/TransactionBuildingService.cs
@@ -26,6 +26,7 @@ using System.Text;
 using OutputReference = Cardano.Sync.Data.Models.Datums.OutputReference;
 using Coinecta.Data.Models.Api.Request;
 using Microsoft.Extensions.Configuration;
+using Cardano.Sync.Data.Models;
 
 namespace Coinecta.Data.Services;
 public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbContextFactory, IConfiguration configuration)

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -165,13 +165,27 @@ public static class CoinectaUtils
         int limit = 20, ulong feeBuffer = 0uL)
     {
         OptimizedRandomImproveStrategy coinSelectionStrategy = new();
-        MultiSplitChangeSelectionStrategy changeCreationStrategy = new();
+        SingleTokenBundleStrategy changeCreationStrategy = new();
         CoinSelectionService coinSelectionService = new(coinSelectionStrategy, changeCreationStrategy);
 
-        CoinSelection result = coinSelectionService
-            .GetCoinSelection(outputs, utxos, changeAddress, mint, requiredUtxos, limit, feeBuffer);
+        int retry = 0;
 
-        return result;
+        while (retry < 10)
+        {
+            try
+            {
+                CoinSelection result = coinSelectionService
+                    .GetCoinSelection(outputs, utxos, changeAddress, mint, requiredUtxos, limit, feeBuffer);
+
+                return result;
+            }
+            catch
+            {
+                retry++;
+            }
+        }
+
+        throw new Exception("Coin selection failed");
     }
 
     public static List<Utxo> GetPureAdaUtxos(List<Utxo> utxos)

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -170,7 +170,7 @@ public static class CoinectaUtils
 
         int retry = 0;
 
-        while (retry < 10)
+        while (retry < 100)
         {
             try
             {

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -164,7 +164,7 @@ public static class CoinectaUtils
         List<Utxo>? requiredUtxos = null,
         int limit = 20, ulong feeBuffer = 0uL)
     {
-        OptimizedRandomImproveStrategy coinSelectionStrategy = new();
+        RandomImproveStrategy coinSelectionStrategy = new();
         MultiSplitChangeSelectionStrategy changeCreationStrategy = new();
         CoinSelectionService coinSelectionService = new(coinSelectionStrategy, changeCreationStrategy);
 

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -165,7 +165,7 @@ public static class CoinectaUtils
         int limit = 20, ulong feeBuffer = 0uL)
     {
         OptimizedRandomImproveStrategy coinSelectionStrategy = new();
-        SingleTokenBundleStrategy changeCreationStrategy = new();
+        MultiSplitChangeSelectionStrategy changeCreationStrategy = new();
         CoinSelectionService coinSelectionService = new(coinSelectionStrategy, changeCreationStrategy);
 
         int retry = 0;

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -165,7 +165,7 @@ public static class CoinectaUtils
         int limit = 20, ulong feeBuffer = 0uL)
     {
         OptimizedRandomImproveStrategy coinSelectionStrategy = new();
-        SingleTokenBundleStrategy changeCreationStrategy = new();
+        MultiSplitChangeSelectionStrategy changeCreationStrategy = new();
         CoinSelectionService coinSelectionService = new(coinSelectionStrategy, changeCreationStrategy);
 
         CoinSelection result = coinSelectionService

--- a/src/Coinecta.Sync/Coinecta.Sync.csproj
+++ b/src/Coinecta.Sync/Coinecta.Sync.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.16-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.17-alpha" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Pallas.NET" Version="0.1.27" />
   </ItemGroup>

--- a/src/Coinecta.Sync/Coinecta.Sync.csproj
+++ b/src/Coinecta.Sync/Coinecta.Sync.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.1" />
     <PackageReference Include="CborSerializer" Version="1.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.1">
@@ -16,9 +16,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
-    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.13-alpha" />
+    <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.16-alpha" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.23" />
+    <PackageReference Include="Pallas.NET" Version="0.1.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Sync/Coinecta.Sync.csproj
+++ b/src/Coinecta.Sync/Coinecta.Sync.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.17-alpha" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Pallas.NET" Version="0.1.27" />
+    <PackageReference Include="Pallas.NET" Version="0.1.28" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Coinecta.Sync/Reducers/StakePoolByAddressReducer.cs
+++ b/src/Coinecta.Sync/Reducers/StakePoolByAddressReducer.cs
@@ -8,6 +8,7 @@ using Cardano.Sync.Reducers;
 using Coinecta.Data.Models.Reducers;
 using Cardano.Sync.Data.Models.Datums;
 using Coinecta.Data.Models.Enums;
+using Cardano.Sync.Data.Models;
 
 namespace Coinecta.Sync.Reducers;
 
@@ -43,7 +44,7 @@ public class StakePoolByAddressReducer(
         _dbContext.Dispose();
     }
 
-    private async Task ProcessInputAync(Block block, TransactionBody tx)
+    private async Task ProcessInputAync(PallasDotnet.Models.Block block, TransactionBody tx)
     {
         foreach (TransactionInput input in tx.Inputs)
         {
@@ -82,7 +83,7 @@ public class StakePoolByAddressReducer(
         }
     }
 
-    private Task ProcessOutputAync(Block block, TransactionBody tx)
+    private Task ProcessOutputAync(PallasDotnet.Models.Block block, TransactionBody tx)
     {
         tx.Outputs.ToList().ForEach(output =>
         {

--- a/src/Coinecta.Sync/Reducers/StakePositionByStakeKeyReducer.cs
+++ b/src/Coinecta.Sync/Reducers/StakePositionByStakeKeyReducer.cs
@@ -8,6 +8,8 @@ using Coinecta.Data.Models.Reducers;
 using Cardano.Sync.Data.Models.Datums;
 using Cardano.Sync.Reducers;
 using Coinecta.Data.Models.Enums;
+using Cardano.Sync.Data.Models;
+using TransactionOutput = PallasDotnet.Models.TransactionOutput;
 
 namespace Coinecta.Sync.Reducers;
 
@@ -44,7 +46,7 @@ public class StakePositionByStakeKeyReducer(
     }
 
 
-    private async Task ProcessInputAync(Block block, TransactionBody tx)
+    private async Task ProcessInputAync(PallasDotnet.Models.Block block, TransactionBody tx)
     {
         // Collect input id and index as tuples
         foreach (TransactionInput input in tx.Inputs)
@@ -82,7 +84,7 @@ public class StakePositionByStakeKeyReducer(
         }
     }
 
-    private async Task ProcessOutputAync(Block block, TransactionBody tx)
+    private async Task ProcessOutputAync(PallasDotnet.Models.Block block, TransactionBody tx)
     {
         foreach (TransactionOutput output in tx.Outputs)
         {
@@ -93,7 +95,7 @@ public class StakePositionByStakeKeyReducer(
                 string pkh = Convert.ToHexString(address.GetPublicKeyHash()).ToLowerInvariant();
                 if (pkh == configuration["CoinectaTimelockValidatorHash"])
                 {
-                    if (output.Datum is not null && output.Datum.Type == DatumType.InlineDatum)
+                    if (output.Datum is not null && output.Datum.Type == PallasDotnet.Models.DatumType.InlineDatum)
                     {
                         byte[] datum = output.Datum.Data;
                         try

--- a/src/Coinecta.Sync/Reducers/StakeRequestByAddressReducer.cs
+++ b/src/Coinecta.Sync/Reducers/StakeRequestByAddressReducer.cs
@@ -10,6 +10,7 @@ using Cardano.Sync.Data.Models.Datums;
 using CardanoSharp.Wallet.Utilities;
 using CardanoSharp.Wallet.Enums;
 using Coinecta.Data.Utils;
+using Cardano.Sync.Data.Models;
 
 namespace Coinecta.Sync.Reducers;
 
@@ -110,7 +111,7 @@ public class StakeRequestByAddressReducer(
                     var pkh = Convert.ToHexString(address.GetPublicKeyHash()).ToLowerInvariant();
                     if (pkh == configuration["CoinectaStakeProxyValidatorHash"])
                     {
-                        if (output.Datum is not null && output.Datum.Type == DatumType.InlineDatum)
+                        if (output.Datum is not null && output.Datum.Type == PallasDotnet.Models.DatumType.InlineDatum)
                         {
                             var datum = output.Datum.Data;
                             try

--- a/src/Coinecta.Tests/Coinecta.Tests.csproj
+++ b/src/Coinecta.Tests/Coinecta.Tests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Dahomey.Cbor" Version="1.21.0" />
     <PackageReference Include="PeterO.Cbor" Version="4.5.3" />
     <PackageReference Include="SAIB.Cardano.Sync" Version="0.2.10-alpha" />
-    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.0" />
+    <PackageReference Include="SAIB.CardanoSharp.Wallet" Version="7.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="System.Formats.Cbor" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
Integrates CardanoNodeClient for fetching utxo instead of relying on API and UtxoByAddress Reducer. This simplifies UTXO fetching for Catcher. Catcher uses its own connection to node to give us an option to use a different node for this service instead of relying on the one the API uses. 

This PR is dependent on #4 and closes #6. 