### PR TITLE
fix(distributor): handle errors when submitting airdrop tx

### DIFF
--- a/src/Coinecta.Distributor/Coinecta.Distributor.csproj
+++ b/src/Coinecta.Distributor/Coinecta.Distributor.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
     <PackageReference Include="Pallas.NET" Version="0.1.28" />
   </ItemGroup>
 

--- a/src/Coinecta.Distributor/Program.cs
+++ b/src/Coinecta.Distributor/Program.cs
@@ -1,13 +1,27 @@
 using Coinecta.Distributor;
+using Polly;
+using Polly.Extensions.Http;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.Services.AddHostedService<Worker>();
 
-
 builder.Services.AddHttpClient("SubmitApi", client =>
 {
     client.BaseAddress = new Uri(builder.Configuration["CardanoSubmitApiUrl"]!);
-});
+})
+.AddPolicyHandler(GetRetryPolicy());
 
 IHost host = builder.Build();
 host.Run();
+
+static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+{
+    return HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+        .WaitAndRetryAsync(8, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(3, retryAttempt)),
+            onRetry: (outcome, timespan, retryAttempt, context) =>
+            {
+                Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds} seconds");
+            });
+}

--- a/src/Coinecta.Distributor/Program.cs
+++ b/src/Coinecta.Distributor/Program.cs
@@ -9,19 +9,17 @@ builder.Services.AddHttpClient("SubmitApi", client =>
 {
     client.BaseAddress = new Uri(builder.Configuration["CardanoSubmitApiUrl"]!);
 })
-.AddPolicyHandler(GetRetryPolicy());
+.AddPolicyHandler(HttpPolicyExtensions
+    .HandleTransientHttpError()
+    .OrResult(msg => !msg.IsSuccessStatusCode)
+    .WaitAndRetryAsync(8, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(3, retryAttempt)),
+        onRetry: (outcome, timespan, retryAttempt, context) =>
+        {
+            Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds} seconds due to {outcome.Result?.StatusCode}");
+        }
+    )
+);
 
 IHost host = builder.Build();
 host.Run();
 
-static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
-{
-    return HttpPolicyExtensions
-        .HandleTransientHttpError()
-        .OrResult(msg => !msg.IsSuccessStatusCode)
-        .WaitAndRetryAsync(8, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(3, retryAttempt)),
-            onRetry: (outcome, timespan, retryAttempt, context) =>
-            {
-                Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds} seconds due to {outcome.Result?.StatusCode}");
-            });
-}

--- a/src/Coinecta.Distributor/Program.cs
+++ b/src/Coinecta.Distributor/Program.cs
@@ -18,10 +18,10 @@ static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
 {
     return HttpPolicyExtensions
         .HandleTransientHttpError()
-        .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+        .OrResult(msg => !msg.IsSuccessStatusCode)
         .WaitAndRetryAsync(8, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(3, retryAttempt)),
             onRetry: (outcome, timespan, retryAttempt, context) =>
             {
-                Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds} seconds");
+                Console.WriteLine($"Retry {retryAttempt} after {timespan.TotalSeconds} seconds due to {outcome.Result?.StatusCode}");
             });
 }

--- a/src/Coinecta.Distributor/Worker.cs
+++ b/src/Coinecta.Distributor/Worker.cs
@@ -113,7 +113,7 @@ public class Worker(
             string[] entry = line.Item2.Split(',');
             string address = entry[0];
             string lovelaceString = entry[1];
-            ulong lovelace = lovelaceString == "" ? 0 : ulong.Parse(lovelaceString);
+            ulong lovelace = string.IsNullOrEmpty(lovelaceString) ? 0 : ulong.Parse(lovelaceString);
 
             // Assets are the column names starting from the 3rd column, and the cells contain the amount
             // Except for the last column which is the transaction hash
@@ -127,7 +127,7 @@ public class Worker(
                 string policyId = unit[..56];
                 string assetName = unit[56..];
 
-                if (u == "") return null;
+                if (string.IsNullOrEmpty(u)) return null;
 
                 return new Asset()
                 {

--- a/src/Coinecta.Distributor/Worker.cs
+++ b/src/Coinecta.Distributor/Worker.cs
@@ -220,7 +220,6 @@ public class Worker(
             .Select(l => string.Join(',', l.Split(',').Take(l.Split(',').Length - 1)))
             .ToList();
 
-        // Get the processing.csv header and attach processedEntries to the body
         var dateTime = $"{DateTime.Now:yyyy-MM-dd-HH-mm-ss}";
 
         // Write header + processedEntries to a new file


### PR DESCRIPTION
### Overview
The initial distributor implementation does not handle errors when submitting transactions via submit-api. It skips the transactions that failed and those transactions need to be reprocessed manually as a result of this design. This PR fixes this issue by adding retry policy on the http client for submitting transaction using Polly .NET to make transactions more likely to be processed successfully. 

### Minor change to distributor logic
Initially the distributor just skips failed transactions and still processes the remaining transactions after failure. Now the program exits on the first unsuccessful transaction after generating the processed and unprocessed csv files.

### Changes to files
File names generated by the distributor can be confusing, to address this the distributor now creates clearer file names for each state of the airdrop.

*It used to be:*
- `distribution.csv` ->  initial file containing raw entries for airdrop
- `processed.csv` -> same with distribution.csv but with transaction_hash column
- `processed-date.csv` -> file with both processed and unprocessed transactions

*Now it's:*
- `distribution.csv` -> initial file containing raw entries for airdrop
- `processing.csv` -> same with distribution.csv but with transaction_hash column, the current airdrop batch being processed
- `processed-date.csv` -> contains only successful transactions with transaction_hash 
- `unprocessed-date.csv` -> all unsuccessful transactions, this can be renamed to distribution.csv for reprocessing after manual checking

This PR closes #13.