### PR TITLE
fix(backend): output too low when redeeming

### DIFF
--- a/src/Coinecta.Data/Models/Api/Request/ClaimStakeRequest.cs
+++ b/src/Coinecta.Data/Models/Api/Request/ClaimStakeRequest.cs
@@ -4,5 +4,6 @@ public record ClaimStakeRequest
 {
     public IEnumerable<OutputReference> StakeUtxoOutputReferences { get; init; } = default!;
     public IEnumerable<string> WalletUtxoListCbor { get; init; } = default!;
+    public string? CollateralUtxoCbor { get; init; } = default;
     public string ChangeAddress { get; init; } = default!;
 }

--- a/src/Coinecta.Data/Services/TransactionBuildingService.cs
+++ b/src/Coinecta.Data/Services/TransactionBuildingService.cs
@@ -255,7 +255,6 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
         ITransactionBodyBuilder txBodyBuilder = TransactionBodyBuilder.Create;
         List<RedeemerBuilder> redeemerBuilders = [];
         ITokenBundleBuilder mintAssets = TokenBundleBuilder.Create;
-        Dictionary<string, Dictionary<string, ulong>> multiAssetWalletOutput = [];
         ITokenBundleBuilder walletBurnAssets = TokenBundleBuilder.Create;
 
         // Total Wallet Output
@@ -268,6 +267,8 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
                 MultiAsset = []
             }
         };
+
+        Dictionary<string, Dictionary<string, long>> stakeOutputs = [];
 
         ulong lowestLockTime = 0;
         stakePositions.ForEach(stakePosition =>
@@ -285,41 +286,13 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
                 Index = (uint)stakePosition.TxIndex
             };
 
-            ITokenBundleBuilder multiAssetInput = TokenBundleBuilder.Create;
-            stakePosition.Amount.MultiAsset.Keys.ToList().ForEach((policyId) =>
-            {
-                Dictionary<string, ulong> asset = stakePosition.Amount.MultiAsset[policyId];
-                asset.Keys.ToList().ForEach((assetName) =>
-                {
-                    byte[] policyIdBytes = Convert.FromHexString(policyId);
-                    byte[] assetNameBytes = Convert.FromHexString(assetName);
+            // Convert ulong to long
+            var stakeInput = CoinectaUtils.ConvertMultiAssetValueToLong(stakePosition.Amount.MultiAsset);
+            var stakeOutputMultiAsset = stakePosition.Amount.MultiAsset;
+            stakeOutputMultiAsset[stakeMintingPolicy].Remove(referenceAssetName);
+            Dictionary<string, Dictionary<string, long>> stakeOutput = CoinectaUtils.ConvertMultiAssetValueToLong(stakeOutputMultiAsset);
 
-                    multiAssetInput.AddToken(policyIdBytes, assetNameBytes, (long)asset[assetName]);
-
-                    if (assetName != referenceAssetName)
-                    {
-                        bool exists = multiAssetWalletOutput.ContainsKey(policyId);
-
-                        if (exists)
-                        {
-                            bool assetExists = multiAssetWalletOutput[policyId].ContainsKey(assetName);
-
-                            if (assetExists)
-                            {
-                                multiAssetWalletOutput[policyId][assetName] += asset[assetName];
-                            }
-                            else
-                            {
-                                multiAssetWalletOutput[policyId].Add(assetName, asset[assetName]);
-                            }
-                        }
-                        else
-                        {
-                            multiAssetWalletOutput.Add(policyId, new() { { assetName, asset[assetName] } });
-                        }
-                    }
-                });
-            });
+            stakeOutputs = TokenUtility.MergeStringDictionaries(stakeOutputs, stakeOutput);
 
             TransactionOutput stakePositionOutput = new()
             {
@@ -327,7 +300,7 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
                 Value = new()
                 {
                     Coin = stakePosition.Amount.Coin,
-                    MultiAsset = multiAssetInput.Build()
+                    MultiAsset = TokenUtility.ConvertStringKeysToByteArrays(stakeInput)
                 },
                 DatumOption = new()
                 {
@@ -350,6 +323,9 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
             walletOutput.Value.Coin += stakePosition.Amount.Coin;
         });
 
+        // Set merged wallet output multiasset
+        walletOutput.Value.MultiAsset = TokenUtility.ConvertStringKeysToByteArrays(stakeOutputs);
+
         // Mint Redeemer
         RedeemerBuilder? mintRedeemerBuilder = RedeemerBuilder.Create
             .SetTag(RedeemerTag.Mint)
@@ -358,23 +334,7 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
             .SetExUnits(new ExUnits { Mem = 0, Steps = 0 }) as RedeemerBuilder;
 
         redeemerBuilders.Add(mintRedeemerBuilder!);
-
-        ITokenBundleBuilder multiAssetOutputBuilder = TokenBundleBuilder.Create;
-
-        multiAssetWalletOutput.Keys.ToList().ForEach((policyId) =>
-        {
-            Dictionary<string, ulong> asset = multiAssetWalletOutput[policyId];
-            asset.Keys.ToList().ForEach((assetName) =>
-            {
-                byte[] policyIdBytes = Convert.FromHexString(policyId);
-                byte[] assetNameBytes = Convert.FromHexString(assetName);
-                multiAssetOutputBuilder.AddToken(policyIdBytes, assetNameBytes, (long)asset[assetName]);
-            });
-        });
-
-        walletOutput.Value.MultiAsset = multiAssetOutputBuilder.Build();
         txBodyBuilder.SetMint(mintAssets);
-
         txBodyBuilder.SetScriptDataHash(
             redeemerBuilders.Select(redeemerBuilder => redeemerBuilder!.Build()).ToList(),
             [],
@@ -405,11 +365,10 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
         CoinSelection stakeKeyInputsResult = CoinectaUtils.GetCoinSelection([nftOutput], walletUtxos, walletAddress.ToString());
 
         stakeKeyInputsResult.SelectedUtxos.ForEach(input => txBodyBuilder.AddInput(input));
-        stakeKeyInputsResult.ChangeOutputs.ForEach(output => txBodyBuilder.AddOutput(output));
         stakeKeyInputsResult.SelectedUtxos.ForEach(utxo => walletUtxos.Remove(item: utxo));
 
         // Add last change output to the wallet output
-        TransactionOutput lastChangeOutput = txBodyBuilder.Build().TransactionOutputs.Last();
+        TransactionOutput lastChangeOutput = stakeKeyInputsResult.ChangeOutputs.First();
 
         ulong finalWalletOutputLovelace = walletOutput.Value.Coin + lastChangeOutput.Value.Coin;
         Dictionary<byte[], NativeAsset> finalWalletOutputMultiAsset = TokenUtility.ConvertStringKeysToByteArrays(TokenUtility.MergeStringDictionaries(
@@ -417,30 +376,36 @@ public class TransactionBuildingService(IDbContextFactory<CoinectaDbContext> dbC
             TokenUtility.ConvertKeysToHexStrings(lastChangeOutput.Value.MultiAsset)
         ));
 
-        TransactionOutput finalWalletOutput = new()
-        {
-            Value = new()
-            {
-                Coin = finalWalletOutputLovelace,
-                MultiAsset = finalWalletOutputMultiAsset
-            }
-        };
+        walletOutput.Value.Coin = finalWalletOutputLovelace;
+        walletOutput.Value.MultiAsset = finalWalletOutputMultiAsset;
 
-        txBodyBuilder.AddOutput(finalWalletOutput);
+        txBodyBuilder.AddOutput(walletOutput);
 
         // Coin Selection for Collateral
-        TransactionOutput collateralOutput = new()
+        if (!string.IsNullOrEmpty(request.CollateralUtxoCbor))
         {
-            Address = walletAddress.GetBytes(),
-            Value = new()
+            var collateral = CoinectaUtils.ConvertUtxoListCbor([request.CollateralUtxoCbor]).First();
+            txBodyBuilder.AddCollateralInput(new()
             {
-                Coin = 5_000_000,
-            }
-        };
+                TransactionId = Convert.FromHexString(collateral.TxHash),
+                TransactionIndex = collateral.TxIndex,
+            });
+        }
+        else
+        {
+            TransactionOutput collateralOutput = new()
+            {
+                Address = walletAddress.GetBytes(),
+                Value = new()
+                {
+                    Coin = 5_000_000,
+                }
+            };
 
-        walletUtxos = CoinectaUtils.GetPureAdaUtxos(walletUtxos);
-        CoinSelection collateralInputResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, walletAddress.ToString(), limit: 1);
-        collateralInputResult.Inputs.ForEach(input => txBodyBuilder.AddCollateralInput(input));
+            walletUtxos = CoinectaUtils.GetPureAdaUtxos(walletUtxos);
+            CoinSelection collateralInputResult = CoinectaUtils.GetCoinSelection([collateralOutput], walletUtxos, walletAddress.ToString(), limit: 1);
+            collateralInputResult.Inputs.ForEach(input => txBodyBuilder.AddCollateralInput(input));
+        }
 
         List<TransactionInput> txInputs = [.. txBodyBuilder.Build().TransactionInputs];
         txInputs.Sort((a, b) =>

--- a/src/Coinecta.Data/Utils/CoinectaUtils.cs
+++ b/src/Coinecta.Data/Utils/CoinectaUtils.cs
@@ -267,6 +267,28 @@ public static class CoinectaUtils
         return balanceAssets;
     }
 
+    public static Dictionary<string, Dictionary<string, long>> ConvertMultiAssetValueToLong(Dictionary<string, Dictionary<string, ulong>> multiAsset)
+    {
+        Dictionary<string, Dictionary<string, long>> convertedStakeInput = [];
+        foreach (var outerPair in multiAsset)
+        {
+            Dictionary<string, long> innerDict = [];
+            foreach (var innerPair in outerPair.Value)
+            {
+                // Convert ulong to long by casting
+                // Ensure that the ulong value is within the range of long to avoid data loss or runtime errors
+                if (innerPair.Value <= (ulong)long.MaxValue)
+                    innerDict.Add(innerPair.Key, (long)innerPair.Value);
+                else
+                    throw new OverflowException($"Value too large to convert to long: {innerPair.Value}");
+            }
+
+            convertedStakeInput.Add(outerPair.Key, innerDict);
+        }
+
+        return convertedStakeInput;
+    }
+
     public static List<Utxo> ConvertUtxosByAddressToUtxo(List<UtxoByAddress> utxosByAddress)
     {
         List<Utxo> resolvedUtxos = utxosByAddress

--- a/src/Coinecta.Distributor/Utils.cs
+++ b/src/Coinecta.Distributor/Utils.cs
@@ -31,7 +31,7 @@ public static class Utils
             txOutputBuilder.SetAddress(new Address(output.Address).GetBytes());
             txOutputBuilder.SetTransactionOutputValue(outputValue);
 
-            var minLovelaceRequired = CalculateMinAdaRequired(txOutputBuilder.Build());
+            var minLovelaceRequired = txOutputBuilder.Build().CalculateMinUtxoLovelace();
             var lovelaceAmount = Math.Max(minLovelaceRequired, output.Lovelace);
 
             outputValue.Coin = lovelaceAmount;
@@ -163,7 +163,7 @@ public static class Utils
 
     public static Utxo MapUtxoByAddressToUtxo(TransactionInput input, TransactionOutput output)
     {
-        Utxo utxo = new Utxo
+        Utxo utxo = new()
         {
             Balance = new Balance(),
             TxHash = input.TransactionId.ToStringHex(),
@@ -201,16 +201,5 @@ public static class Utils
             1177 => NetworkType.Preview,
             _ => throw new NotImplementedException()
         };
-    }
-
-    public static ulong CalculateMinAdaRequired(TransactionOutput output)
-    {
-        var coinPerUtxoWord = 34_482.0;
-        var coinPerUtxoByte = coinPerUtxoWord / 8.0 /* Add buffer? */ + 100;
-
-        // The formula is: (160 + |serialized_output|) * coinsPerUTxOByte
-        var size = output.GetCBOR().EncodeToBytes().Length;
-
-        return (ulong)((160 + size) * coinPerUtxoByte);
     }
 }


### PR DESCRIPTION
### Overview
This PR fixes the issue where the output is too low when redeeming stake position by combining the change utxo with the locked utxo. 

### Minor Changes
- Use CardanoWalletSharp minAda util instead of custom util
- Some code improvements to transaction building service
 